### PR TITLE
fix: resolve tf priority syntax error

### DIFF
--- a/tjr_bullet_indicator.pine
+++ b/tjr_bullet_indicator.pine
@@ -344,10 +344,12 @@ tfPrioByTag(_tag) =>
         => 0
 
 tfPrioByShort(_short) =>
-    _short == "1D"  ? 4 :
-    _short == "4H"  ? 3 :
-    _short == "1H"  ? 2 :
-    _short == "30m" ? 1 : 0
+    switch _short
+        "1D"  => 4
+        "4H"  => 3
+        "1H"  => 2
+        "30m" => 1
+        => 0
 
 isTFTag(_tag) =>
     str.startswith(_tag, "1D") or str.startswith(_tag, "4H") or str.startswith(_tag, "1H") or str.startswith(_tag, "30m")


### PR DESCRIPTION
## Summary
- replace nested ternary in `tfPrioByShort` with `switch` for cleaner logic and valid syntax

## Testing
- `npm test` *(fails: could not read package.json)*

## Checklist
- [ ] TV compiles
- [ ] time markers ok
- [ ] scenario at 15:30 (TLV)
- [ ] no `ta.highest/lowest` scope warnings
- [ ] HTF refresh (4H/1H/30m)

cc @github-copilot

------
https://chatgpt.com/codex/tasks/task_b_68a6099258f88333855df7385623dd8b