### PR TITLE
fix: remove invalid return type in shortFromTf

### DIFF
--- a/tjr_bullet_indicator.pine
+++ b/tjr_bullet_indicator.pine
@@ -354,7 +354,7 @@ tfPrioByShort(_short) =>
 isTFTag(_tag) =>
     str.startswith(_tag, "1D") or str.startswith(_tag, "4H") or str.startswith(_tag, "1H") or str.startswith(_tag, "30m")
 
-string shortFromTf(string _tf) =>
+shortFromTf(string _tf) =>
     _tf == "D"     ? "1D"  :
     _tf == "240"   ? "4H"  :
     _tf == "60"    ? "1H"  :


### PR DESCRIPTION
## Summary
- remove invalid string return type causing compile error

## Testing
- `npm test` (fails: package.json missing)

## Checklist
- [ ] TV compiles
- [ ] time markers ok
- [ ] scenario at 15:30 (TLV)
- [ ] no `ta.highest/lowest` scope warnings
- [ ] HTF refresh (4H/1H/30m)

Requesting review from GitHub Copilot.

------
https://chatgpt.com/codex/tasks/task_b_68a6111dc4d0833395cc97292fd39748