### PR TITLE
fix: resolve isTFTag syntax

### DIFF
--- a/tjr_bullet_indicator.pine
+++ b/tjr_bullet_indicator.pine
@@ -352,7 +352,10 @@ tfPrioByShort(_short) =>
         => 0
 
 isTFTag(_tag) =>
-    str.startswith(_tag, "1D") or str.startswith(_tag, "4H") or str.startswith(_tag, "1H") or str.startswith(_tag, "30m")
+    str.startswith(_tag, "1D") or
+    str.startswith(_tag, "4H") or
+    str.startswith(_tag, "1H") or
+    str.startswith(_tag, "30m")
 
 shortFromTf(string _tf) =>
     _tf == "D"     ? "1D"  :


### PR DESCRIPTION
## Summary
- split `isTFTag` onto multiple lines to fix syntax error

## Testing
- `npm test` *(fails: package.json missing)*

## Checklist
- [ ] TV compiles
- [ ] time markers ok
- [ ] scenario at 15:30 (TLV)
- [ ] no `ta.highest/lowest` scope warnings
- [ ] HTF refresh (4H/1H/30m)

Requesting GitHub Copilot review.

------
https://chatgpt.com/codex/tasks/task_b_68a6128622d48333a9fb433ba857e270