### PR TITLE
fix: cap boxes via constant

### DIFF
--- a/tjr_bullet_indicator.pine
+++ b/tjr_bullet_indicator.pine
@@ -5,6 +5,7 @@ indicator("TJR Bolt • Full (v1.4.4-ui-align+4H)", overlay=true, max_lines_coun
 //========================= Object store =========================
 const int MAX_LINES  = 500
 const int MAX_LABELS = 300
+const int MAX_BOXES  = 180
 
 var line[]  gLines  = array.new_line()
 var label[] gLabels = array.new_label()
@@ -26,7 +27,7 @@ trackLabel(id) =>
 trackBox(id) =>
     if not na(id)
         array.push(gBoxes, id)
-        if array.size(gBoxes) > 180
+        if array.size(gBoxes) > MAX_BOXES
             box.delete(array.shift(gBoxes))
 
 safeDelLine(ln) =>


### PR DESCRIPTION
## Summary
- define `MAX_BOXES` constant and use it when tracking boxes

## Testing
- `npm test` *(fails: could not read package.json)*
- `pytest` *(no tests ran)*

## Checklist
- [ ] TV compiles
- [ ] time markers ok
- [ ] scenario at 15:30 (TLV)
- [ ] no `ta.highest/lowest` scope warnings
- [ ] HTF refresh (4H/1H/30m)

Requesting GitHub Copilot review.

------
https://chatgpt.com/codex/tasks/task_b_68a6165c60ec8333a7c7bb1bc4cf1aed