### PR TITLE
Fix TF tag helper causing compilation error

### DIFF
--- a/tjr_bullet_indicator.pine
+++ b/tjr_bullet_indicator.pine
@@ -353,10 +353,12 @@ tfPrioByShort(_short) =>
         => 0
 
 isTFTag(_tag) =>
-    str.startswith(_tag, "1D") or
-    str.startswith(_tag, "4H") or
-    str.startswith(_tag, "1H") or
-    str.startswith(_tag, "30m")
+    switch
+        str.startswith(_tag, "1D")  => true
+        str.startswith(_tag, "4H")  => true
+        str.startswith(_tag, "1H")  => true
+        str.startswith(_tag, "30m") => true
+        => false
 
 shortFromTf(string _tf) =>
     _tf == "D"     ? "1D"  :


### PR DESCRIPTION
## Summary
- fix TF tag detection helper with explicit switch cases

## Testing
- `npx --yes pine --version` *(fails: could not determine executable to run)*
- `pip install --quiet pypinescript` *(fails: no matching distribution found)*

## Checklist
- [ ] TV compiles
- [ ] Time markers ok
- [ ] Scenario at 15:30 (TLV)
- [ ] No ta.highest/lowest scope warnings
- [ ] HTF refresh (4H/1H/30m)

cc @github-copilot

------
https://chatgpt.com/codex/tasks/task_b_68a61a6527e48333998dbc68c3af7264