### PR TITLE
fix: resolve shortFromTf line continuation

### DIFF
--- a/tjr_bullet_indicator.pine
+++ b/tjr_bullet_indicator.pine
@@ -361,10 +361,12 @@ isTFTag(_tag) =>
         => false
 
 shortFromTf(string _tf) =>
-    _tf == "D"     ? "1D"  :
-    _tf == "240"   ? "4H"  :
-    _tf == "60"    ? "1H"  :
-    _tf == "30"    ? "30m" : _tf
+    switch _tf
+        "D"    => "1D"
+        "240"  => "4H"
+        "60"   => "1H"
+        "30"   => "30m"
+        => _tf
 
 // Insert with de-dup and precedence; LQ levels are intraday (persist=false)
 tryInsertLQ(_short, _isHigh, _price, _t) =>


### PR DESCRIPTION
## Summary
- refactor shortFromTf mapping to switch to avoid line continuation issues

## Testing
- `npm test` *(fails: Could not read package.json)*

## Checklist
- [ ] TV compiles
- [ ] time markers ok
- [ ] scenario at 15:30 (TLV)
- [ ] no `ta.highest/lowest` scope warnings
- [ ] HTF refresh (4H/1H/30m)

Requesting review from GitHub Copilot.

------
https://chatgpt.com/codex/tasks/task_b_68a61e1533e08333af643ad7a92828f1