### PR TITLE
Fix array initialization for liquidity collection

### DIFF
--- a/tjr_bullet_indicator.pine
+++ b/tjr_bullet_indicator.pine
@@ -396,30 +396,16 @@ collectLiquidityForTF(_tf, _len) =>
     float lSrc = request.security(syminfo.tickerid, _tf, ta.lowest(low,  _len * 2 + 1)[_len],             barmerge.gaps_off, barmerge.lookahead_off)
     int   pTim = request.security(syminfo.tickerid, _tf, time[_len],                                       barmerge.gaps_off, barmerge.lookahead_off)
 
-    float[] hExtArr = array.from(
-        ta.valuewhen(hPiv, hSrc, 0),  ta.valuewhen(hPiv, hSrc, 1),  ta.valuewhen(hPiv, hSrc, 2),  ta.valuewhen(hPiv, hSrc, 3),
-        ta.valuewhen(hPiv, hSrc, 4),  ta.valuewhen(hPiv, hSrc, 5),  ta.valuewhen(hPiv, hSrc, 6),  ta.valuewhen(hPiv, hSrc, 7),
-        ta.valuewhen(hPiv, hSrc, 8),  ta.valuewhen(hPiv, hSrc, 9),  ta.valuewhen(hPiv, hSrc, 10), ta.valuewhen(hPiv, hSrc, 11),
-        ta.valuewhen(hPiv, hSrc, 12), ta.valuewhen(hPiv, hSrc, 13), ta.valuewhen(hPiv, hSrc, 14), ta.valuewhen(hPiv, hSrc, 15),
-        ta.valuewhen(hPiv, hSrc, 16), ta.valuewhen(hPiv, hSrc, 17), ta.valuewhen(hPiv, hSrc, 18), ta.valuewhen(hPiv, hSrc, 19))
-    int[]   hTimArr = array.from(
-        ta.valuewhen(hPiv, pTim, 0),  ta.valuewhen(hPiv, pTim, 1),  ta.valuewhen(hPiv, pTim, 2),  ta.valuewhen(hPiv, pTim, 3),
-        ta.valuewhen(hPiv, pTim, 4),  ta.valuewhen(hPiv, pTim, 5),  ta.valuewhen(hPiv, pTim, 6),  ta.valuewhen(hPiv, pTim, 7),
-        ta.valuewhen(hPiv, pTim, 8),  ta.valuewhen(hPiv, pTim, 9),  ta.valuewhen(hPiv, pTim, 10), ta.valuewhen(hPiv, pTim, 11),
-        ta.valuewhen(hPiv, pTim, 12), ta.valuewhen(hPiv, pTim, 13), ta.valuewhen(hPiv, pTim, 14), ta.valuewhen(hPiv, pTim, 15),
-        ta.valuewhen(hPiv, pTim, 16), ta.valuewhen(hPiv, pTim, 17), ta.valuewhen(hPiv, pTim, 18), ta.valuewhen(hPiv, pTim, 19))
-    float[] lExtArr = array.from(
-        ta.valuewhen(lPiv, lSrc, 0),  ta.valuewhen(lPiv, lSrc, 1),  ta.valuewhen(lPiv, lSrc, 2),  ta.valuewhen(lPiv, lSrc, 3),
-        ta.valuewhen(lPiv, lSrc, 4),  ta.valuewhen(lPiv, lSrc, 5),  ta.valuewhen(lPiv, lSrc, 6),  ta.valuewhen(lPiv, lSrc, 7),
-        ta.valuewhen(lPiv, lSrc, 8),  ta.valuewhen(lPiv, lSrc, 9),  ta.valuewhen(lPiv, lSrc, 10), ta.valuewhen(lPiv, lSrc, 11),
-        ta.valuewhen(lPiv, lSrc, 12), ta.valuewhen(lPiv, lSrc, 13), ta.valuewhen(lPiv, lSrc, 14), ta.valuewhen(lPiv, lSrc, 15),
-        ta.valuewhen(lPiv, lSrc, 16), ta.valuewhen(lPiv, lSrc, 17), ta.valuewhen(lPiv, lSrc, 18), ta.valuewhen(lPiv, lSrc, 19))
-    int[]   lTimArr = array.from(
-        ta.valuewhen(lPiv, pTim, 0),  ta.valuewhen(lPiv, pTim, 1),  ta.valuewhen(lPiv, pTim, 2),  ta.valuewhen(lPiv, pTim, 3),
-        ta.valuewhen(lPiv, pTim, 4),  ta.valuewhen(lPiv, pTim, 5),  ta.valuewhen(lPiv, pTim, 6),  ta.valuewhen(lPiv, pTim, 7),
-        ta.valuewhen(lPiv, pTim, 8),  ta.valuewhen(lPiv, pTim, 9),  ta.valuewhen(lPiv, pTim, 10), ta.valuewhen(lPiv, pTim, 11),
-        ta.valuewhen(lPiv, pTim, 12), ta.valuewhen(lPiv, pTim, 13), ta.valuewhen(lPiv, pTim, 14), ta.valuewhen(lPiv, pTim, 15),
-        ta.valuewhen(lPiv, pTim, 16), ta.valuewhen(lPiv, pTim, 17), ta.valuewhen(lPiv, pTim, 18), ta.valuewhen(lPiv, pTim, 19))
+    float[] hExtArr = array.new_float(N)
+    int[]   hTimArr = array.new_int(N)
+    float[] lExtArr = array.new_float(N)
+    int[]   lTimArr = array.new_int(N)
+
+    for i = 0 to N - 1
+        array.set(hExtArr, i, ta.valuewhen(hPiv, hSrc, i))
+        array.set(hTimArr, i, ta.valuewhen(hPiv, pTim, i))
+        array.set(lExtArr, i, ta.valuewhen(lPiv, lSrc, i))
+        array.set(lTimArr, i, ta.valuewhen(lPiv, pTim, i))
 
     bool foundH = false
     bool foundL = false


### PR DESCRIPTION
## Summary
- replace `array.from` with explicit loops to fill liquidity arrays

## Testing
- `node -e "console.log('no tests');"`

## Checklist
- [ ] TV compiles
- [ ] time markers ok
- [ ] scenario at 15:30 (TLV)
- [ ] no `ta.highest/lowest` scope warnings
- [ ] HTF refresh (4H/1H/30m)

cc @github-copilot

------
https://chatgpt.com/codex/tasks/task_b_68a63630116483338904d44ac629c1e0