### PR TITLE
fix: nightly cleanup resets zones and flags

### DIFF
--- a/tjr_bullet_indicator.pine
+++ b/tjr_bullet_indicator.pine
@@ -541,6 +541,25 @@ if fStart("2300-2301")
         for k = bxN - 1 to 0
             safeDelBox(array.get(gBoxes, k))
         array.clear(gBoxes)
+    int zN = array.size(zones)
+    if zN > 0
+        for zi = zN - 1 to 0
+            Zone z = array.get(zones, zi)
+            safeDelBox(z.bx)
+            safeDelLine(z.mid)
+            safeDelLine(z.topLn)
+            safeDelLine(z.botLn)
+            safeDelLabel(z.tag)
+        array.clear(zones)
+    hasDS := false
+    hasCT := false
+    dsTime := na
+    ctTime := na
+    chosenIdx := na
+    oneMinTouched := false
+    oneMinConfirmed := false
+    entryPx := na
+    entryTs := na
     safeDelLine(asiaHLn)
     safeDelLine(asiaLLn)
     asiaHLn := na


### PR DESCRIPTION
## Summary
- extend nightly cleanup to purge zones and reset state

## Testing
- `node -v`

## Checklist
- [ ] TV compiles
- [ ] Time markers ok
- [ ] Scenario at 15:30 (TLV)
- [ ] No `ta.highest/lowest` scope warnings
- [ ] HTF refresh (4H/1H/30m)

cc @github-copilot

------
https://chatgpt.com/codex/tasks/task_b_68a6385f6fb08333828f0818bea68390