### PR TITLE
fix: guard reset_state arrays

### DIFF
--- a/tjr_bullet_indicator.pine
+++ b/tjr_bullet_indicator.pine
@@ -35,10 +35,11 @@ var float[] bottoms = array.new_float()
 MAX_BPR = 500
 
 reset_state() =>
-    for i = 0 to array.size(bprs) - 1
-        box.delete(array.get(bprs, i))
-        line.delete(array.get(mids, i))
-        label.delete(array.get(tags, i))
+    if array.size(bprs) > 0
+        for i = 0 to array.size(bprs) - 1
+            box.delete(array.get(bprs, i))
+            line.delete(array.get(mids, i))
+            label.delete(array.get(tags, i))
     array.clear(bprs)
     array.clear(mids)
     array.clear(tags)


### PR DESCRIPTION
## Summary
- prevent array.get out of bounds in `reset_state`

## Testing
- `npm test` *(fails: Could not read package.json)*

## Checklist
- [ ] TV compiles
- [ ] time markers ok
- [ ] scenario at 15:30 (TLV)
- [ ] no `ta.highest/lowest` scope warnings
- [ ] HTF refresh (4H/1H/30m)

Requesting review from GitHub Copilot.

------
https://chatgpt.com/codex/tasks/task_b_68adbecf01188333976763d9b491d107