### PR TITLE
fix: avoid global reassignment in reset_state

### DIFF
--- a/tjr_bullet_indicator.pine
+++ b/tjr_bullet_indicator.pine
@@ -55,15 +55,15 @@ reset_state() =>
     array.clear(dirs)
     array.clear(tops)
     array.clear(bottoms)
+
+if session_open or cleanup
+    reset_state()
     topB := na
     botB := na
     tB := na
     topS := na
     botS := na
     tS := na
-
-if session_open or cleanup
-    reset_state()
 
 fill_transp = 100 - bpr_opacity
 bpr_fill = color.new(bpr_color, fill_transp)


### PR DESCRIPTION
## Summary
- refactor reset_state to avoid modifying global vars

## Testing
- `npm test` *(fails: could not read package.json)*

## Checklist
- [ ] TV compiles
- [ ] Time markers ok
- [ ] Scenario at 15:30 (TLV)
- [ ] No `ta.highest/lowest` scope warnings
- [ ] HTF refresh (4H/1H/30m)

cc @github-copilot

------
https://chatgpt.com/codex/tasks/task_b_68adcca84ce08333bcb5e7b878f025ac