### PR TITLE
fix: ensure bool getter returns typed na

### DIFF
--- a/tjr_bullet_indicator.pine
+++ b/tjr_bullet_indicator.pine
@@ -27,7 +27,7 @@ getFloat(float[] a, int i) =>
 getInt(int[] a, int i) =>
     (i >= 0 and i < array.size(a)) ? array.get(a, i) : na
 getBool(bool[] a, int i) =>
-    (i >= 0 and i < array.size(a)) ? array.get(a, i) : na
+    (i >= 0 and i < array.size(a)) ? array.get(a, i) : bool(na)
 
 // Session presence helper: only use this for session checks
 inSess(tf, s, tz) =>


### PR DESCRIPTION
## Summary
- fix bool getter to return `bool(na)` when index out of bounds

## Testing
- `rg -n 'ta\.highest|ta\.lowest' tjr_bullet_indicator.pine || echo 'no ta highest/lowest'`
- `rg -n 'barstate.isfirst' tjr_bullet_indicator.pine || echo 'no barstate.isfirst'`

cc: @github-copilot

## Checklist
- [ ] TV compiles
- [ ] time markers ok
- [ ] scenario at 15:30 (TLV)
- [ ] no `ta.highest/lowest` scope warnings
- [ ] HTF refresh (4H/1H/30m)


------
https://chatgpt.com/codex/tasks/task_b_68ae360cbdd08333bc407afd359621b6