### PR TITLE
fix: cast na to bool for confirmed bar helper

### DIFF
--- a/tjr_bullet_indicator.pine
+++ b/tjr_bullet_indicator.pine
@@ -35,7 +35,7 @@ inSess(tf, s, tz) =>
 
 // Confirmed bar helper for any pattern logic
 confirmOn(tf, cond) =>
-    secConf = request.security(syminfo.tickerid, tf, barstate.isconfirmed ? cond : na, gaps=barmerge.gaps_off, lookahead=barmerge.lookahead_off)
+    request.security(syminfo.tickerid, tf, barstate.isconfirmed ? cond : bool(na), gaps=barmerge.gaps_off, lookahead=barmerge.lookahead_off)
     // Returns cond only when bar is confirmed
 
 //----------------------------------------------------------//


### PR DESCRIPTION
## Summary
- cast `na` to `bool(na)` in `confirmOn` to satisfy operator `?:`

## Testing
- `npm test` *(fails: Could not read package.json)*

## Checklist
- [ ] TV compiles
- [ ] time markers ok
- [ ] scenario at 15:30 (TLV)
- [ ] no `ta.highest/lowest` scope warnings
- [ ] HTF refresh (4H/1H/30m)


------
https://chatgpt.com/codex/tasks/task_b_68ae3709786c8333976d91fb5ce44e71