### PR TITLE
fix: correct box deletion helpers

### DIFF
--- a/tjr_bullet_indicator.pine
+++ b/tjr_bullet_indicator.pine
@@ -1,10 +1,19 @@
 //@version=6
-indicator("BPR [TakingProphets]", overlay=true, max_bars_back=500, max_boxes_count=500, max_lines_count=500, max_labels_count=500)
+indicator("BPR [TakingProphets]", overlay=true, max_bars_back=500,
+    max_boxes_count=500, max_lines_count=500, max_labels_count=500)
 
 //----------------- UTILITIES & GUARDRAILS -----------------//
-safeDelBox(x) => if not na(x) box.delete(x)
-safeDelLine(x) => if not na(x) line.delete(x)
-safeDelLabel(x) => if not na(x) label.delete(x)
+safeDelBox(x) =>
+    if not na(x)
+        box.delete(x)
+
+safeDelLine(x) =>
+    if not na(x)
+        line.delete(x)
+
+safeDelLabel(x) =>
+    if not na(x)
+        label.delete(x)
 
 getBox(a, i) => (i >= 0 and i < array.size(a)) ? array.get(a, i) : na
 getLine(a, i) => (i >= 0 and i < array.size(a)) ? array.get(a, i) : na


### PR DESCRIPTION
## Summary
- fix function syntax for box/line/label deletion helpers
- ensure indicator configuration line is complete

## Testing
- `rg "ta\.highest"`
- `rg "ta\.lowest"`

## Checklist
- [ ] TV compiles
- [ ] Time markers ok
- [ ] Scenario at 15:30 (TLV)
- [ ] No ta.highest/lowest scope warnings
- [ ] HTF refresh (4H/1H/30m)


------
https://chatgpt.com/codex/tasks/task_b_68b06773081c8333abf1892b43bb226c