### PR TITLE
fix: remove invalid type annotations

### DIFF
--- a/tjr_bullet_indicator.pine
+++ b/tjr_bullet_indicator.pine
@@ -2,9 +2,9 @@
 indicator("BPR [TakingProphets]", overlay=true, max_bars_back=500, max_boxes_count=500, max_lines_count=500, max_labels_count=500)
 
 //----------------- UTILITIES & GUARDRAILS -----------------//
-safeDelBox(box x) => if not na(x) box.delete(x)
-safeDelLine(line x) => if not na(x) line.delete(x)
-safeDelLabel(label x) => if not na(x) label.delete(x)
+safeDelBox(x) => if not na(x) box.delete(x)
+safeDelLine(x) => if not na(x) line.delete(x)
+safeDelLabel(x) => if not na(x) label.delete(x)
 
 getBox(a, i)   => (i >= 0 and i < array.size(a)) ? array.get(a, i) : box(na)
 getLine(a, i)  => (i >= 0 and i < array.size(a)) ? array.get(a, i) : line(na)


### PR DESCRIPTION
## Summary
- remove type annotations from safe deletion helpers

## Testing
- `rg test`

cc @github-copilot

## Checklist
- [ ] TV compiles
- [ ] time markers ok
- [ ] scenario at 15:30 (TLV)
- [ ] no `ta.highest/lowest` scope warnings
- [ ] HTF refresh (4H/1H/30m)


------
https://chatgpt.com/codex/tasks/task_b_68b0a9712a208333a82a903ba576bd41