### PR TITLE
Fix syntax error in bullet indicator

### DIFF
--- a/tjr_bullet_indicator.pine
+++ b/tjr_bullet_indicator.pine
@@ -1,10 +1,23 @@
 //@version=6
-indicator("BPR [TakingProphets]", overlay=true, max_bars_back=500, max_boxes_count=500, max_lines_count=500, max_labels_count=500)
+indicator(
+    "BPR [TakingProphets]",
+    overlay=true,
+    max_bars_back=500,
+    max_boxes_count=500,
+    max_lines_count=500,
+    max_labels_count=500
+    )
 
 //----------------- UTILITIES & GUARDRAILS -----------------//
-safeDelBox(x) => if not na(x) box.delete(x)
-safeDelLine(x) => if not na(x) line.delete(x)
-safeDelLabel(x) => if not na(x) label.delete(x)
+safeDelBox(x) =>
+    if not na(x)
+        box.delete(x)
+safeDelLine(x) =>
+    if not na(x)
+        line.delete(x)
+safeDelLabel(x) =>
+    if not na(x)
+        label.delete(x)
 
 getBox(a, i)   => (i >= 0 and i < array.size(a)) ? array.get(a, i) : box(na)
 getLine(a, i)  => (i >= 0 and i < array.size(a)) ? array.get(a, i) : line(na)


### PR DESCRIPTION
## Summary
- fix safe deletion helpers
- wrap indicator parameters for readability

## Testing
- `python - <<'PY'
print('no tests specified')
PY`

## Checklist
- [ ] TV compiles
- [ ] time markers ok
- [ ] scenario at 15:30 (TLV)
- [ ] no `ta.highest/lowest` scope warnings
- [ ] HTF refresh (4H/1H/30m)

cc @github-copilot

------
https://chatgpt.com/codex/tasks/task_b_68b0ab6cf1e08333a5cd29728aaf82da