### PR TITLE
Fix indicator syntax for Pine v6

### DIFF
--- a/tjr_bullet_indicator.pine
+++ b/tjr_bullet_indicator.pine
@@ -1,12 +1,5 @@
 //@version=6
-indicator(
-    "BPR [TakingProphets]",
-    overlay=true,
-    max_bars_back=500,
-    max_boxes_count=500,
-    max_lines_count=500,
-    max_labels_count=500
-    )
+indicator("BPR [TakingProphets]", overlay=true, max_bars_back=500, max_boxes_count=500, max_lines_count=500, max_labels_count=500)
 
 //----------------- UTILITIES & GUARDRAILS -----------------//
 safeDelBox(x) =>


### PR DESCRIPTION
## Summary
- fix indicator call to avoid line 2 compilation error

## Testing
- no tests

## Checklist
- [ ] TV compiles
- [ ] time markers ok
- [ ] scenario at 15:30 (TLV)
- [ ] no `ta.highest/lowest` scope warnings
- [ ] HTF refresh (4H/1H/30m)

cc @github-copilot

------
https://chatgpt.com/codex/tasks/task_b_68b0ac8e8cb88333afb5f2024e5717ce