### PR TITLE
Fix inDisplayTF redeclaration error

### DIFF
--- a/tjr_bullet_indicator.pine
+++ b/tjr_bullet_indicator.pine
@@ -215,7 +215,7 @@ sessDisplay = HHMM(displayStart) + "-" + HHMM(displayEnd)
 sessDelete  = HHMM(deleteAt)     + "-" + HHMMplus1(deleteAt)
 TZ = "Asia/Jerusalem"
 inSearch5   = inSess("5", sessSearch, TZ)
-inDisplayTF = inSess(timeframe.period, sessDisplay, TZ)
+inDisplayTF := inSess(timeframe.period, sessDisplay, TZ)
 tDel        = time("1", sessDelete, TZ)
 cleanup     = not na(tDel) and na(tDel[1])
 


### PR DESCRIPTION
## Summary
- use reassignment operator for inDisplayTF to avoid redefining variable

## Testing
- `echo "No test suite present"`

## PR Checklist
- [ ] TV compiles
- [ ] time markers ok
- [ ] scenario at 15:30 (TLV)
- [ ] no `ta.highest/lowest` scope warnings
- [ ] HTF refresh (4H/1H/30m)

Requesting review from @github-copilot

------
https://chatgpt.com/codex/tasks/task_b_68b0ce22e4988333b2af40dfc6aa66b3